### PR TITLE
Add Dynamic Image Viewer with Resizing in Tabs + Spanish translations

### DIFF
--- a/src/main/java/com/sotasan/decompiler/controllers/TabController.java
+++ b/src/main/java/com/sotasan/decompiler/controllers/TabController.java
@@ -2,12 +2,15 @@ package com.sotasan.decompiler.controllers;
 
 import com.sotasan.decompiler.models.FileModel;
 import com.sotasan.decompiler.types.ClassType;
+import com.sotasan.decompiler.types.ImageType;
 import com.sotasan.decompiler.types.Type;
 import com.sotasan.decompiler.views.TabView;
 import lombok.Getter;
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
@@ -20,12 +23,19 @@ public class TabController extends BaseController<TabView> {
     private final FileModel fileModel;
 
     public TabController(@NotNull FileModel fileModel) {
-        super(new TabView());
+        super(new TabView(fileModel));
         this.fileModel = fileModel;
         getView().setController(this);
     }
 
     public CompletableFuture<Void> updateAsync() {
+
+        if (fileModel.getType() instanceof ImageType) {
+            JScrollPane imageScrollPane = new JScrollPane();
+            getView().setScrollPane(imageScrollPane);
+            return CompletableFuture.completedFuture(null);
+        }
+
         return getTextAsync(fileModel)
                 .thenAccept(s -> {
                     getView().getTextArea().setText(s);

--- a/src/main/resources/langs/language_es.properties
+++ b/src/main/resources/langs/language_es.properties
@@ -1,0 +1,15 @@
+file=Archivo
+file.openFile=Abrir Archivo
+file.closeTab=Cerrar Pestaña
+file.newInstance=Nueva Instancia
+file.exit=Salir
+
+help=Ayuda
+
+empty=Ningún archivo abierto
+empty.drag=Arrastra y suelta para abrir un archivo
+
+about=Acerca de
+about.version=Versión %s
+about.vm=Virtual Machine
+about.ok=OK


### PR DESCRIPTION
An image viewer has been added to the setScrollPane method. This viewer dynamically adjusts the size of an image within a JScrollPane based on the component's size.

- Dynamic Resizing: The image viewer resizes the image to maintain its aspect ratio when the component is resized. It ensures the image fits within the available space without distortion.

- Scroll Pane Configuration: The JScrollPane is configured to never show horizontal or vertical scroll bars, providing a clean and uncluttered view.

- Component Resize Handling: A ComponentAdapter is used to handle resize events. When the component is resized, the image dimensions are recalculated to fit within the new size, maintaining the aspect ratio.

- Smooth Scaling: The image is scaled smoothly to provide a high-quality visual experience.

![image](https://github.com/user-attachments/assets/f69d69ca-0ac8-45a9-bf3c-4d459c28a918)
