### PR TITLE
refactor: rewrite the ported sources in idiomatic Kotlin

### DIFF
--- a/src/main/kotlin/moe/sota/decompiler/Main.kt
+++ b/src/main/kotlin/moe/sota/decompiler/Main.kt
@@ -13,7 +13,7 @@ fun main(args: Array<String>) {
     if (SystemInfo.isMacOS) {
         System.setProperty("apple.awt.application.appearance", "NSAppearanceNameDarkAqua")
         System.setProperty("apple.awt.application.name", "Decompiler")
-        System.setProperty("apple.laf.useScreenMenuBar", "${true}")
+        System.setProperty("apple.laf.useScreenMenuBar", "true")
     }
 
     startKoin { modules(controllersModule, menusModule, servicesModule, viewsModule) }

--- a/src/main/kotlin/moe/sota/decompiler/controllers/TabController.kt
+++ b/src/main/kotlin/moe/sota/decompiler/controllers/TabController.kt
@@ -1,9 +1,5 @@
 package moe.sota.decompiler.controllers
 
-import java.io.PrintWriter
-import java.io.StringWriter
-import java.nio.charset.StandardCharsets
-import javax.swing.JScrollPane
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -25,31 +21,26 @@ class TabController(
 
     suspend fun update() {
         if (fileModel.type is ImageType) {
-            val imageScrollPane = JScrollPane()
-            tabView.setScrollPane(imageScrollPane)
+            tabView.showImage()
             return
         }
 
         try {
             val transformer = tabsController.transformer
-            val text = withContext(Dispatchers.Default) { getText(transformer) }
-            tabView.textArea.text = text
-            val type = fileModel.type
-            if (type != null) tabView.textArea.setSyntaxEditingStyle(type.syntax)
+            tabView.textArea.text = withContext(Dispatchers.Default) { getText(transformer) }
+            fileModel.type?.let { tabView.textArea.syntaxEditingStyle = it.syntax }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Throwable) {
-            val stringWriter = StringWriter()
-            e.printStackTrace(PrintWriter(stringWriter))
-            tabView.textArea.text = stringWriter.toString().trim { it <= ' ' }
-            tabView.textArea.setSyntaxEditingStyle(SyntaxConstants.SYNTAX_STYLE_NONE)
+            tabView.textArea.text = e.stackTraceToString().trim()
+            tabView.textArea.syntaxEditingStyle = SyntaxConstants.SYNTAX_STYLE_NONE
         }
 
-        tabView.scrollPane.getHorizontalScrollBar().setValue(0)
-        tabView.scrollPane.getVerticalScrollBar().setValue(0)
+        tabView.scrollPane.horizontalScrollBar.value = 0
+        tabView.scrollPane.verticalScrollBar.value = 0
     }
 
     private fun getText(transformer: Transformer?): String =
         if (fileModel.type is ClassType) transformer!!.newInstance().transform(fileModel)
-        else String(fileModel.bytes, StandardCharsets.UTF_8)
+        else fileModel.bytes.decodeToString()
 }

--- a/src/main/kotlin/moe/sota/decompiler/controllers/TabsController.kt
+++ b/src/main/kotlin/moe/sota/decompiler/controllers/TabsController.kt
@@ -14,41 +14,48 @@ import moe.sota.decompiler.transformers.Transformer
 import moe.sota.decompiler.types.ClassType
 import moe.sota.decompiler.views.TabView
 import moe.sota.decompiler.views.TabsView
-import org.koin.java.KoinJavaComponent.get
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 
 class TabsController(
     private val tabsView: TabsView,
     private val createTabController: (FileModel) -> TabController,
-) : ActionListener, ChangeListener {
+) : ActionListener, ChangeListener, KoinComponent {
+    private val fileCloseTab: FileCloseTab by inject()
     private val scope = MainScope()
 
     val transformer: Transformer?
         get() = tabsView.comboBox.selectedItem as Transformer?
 
+    private val controllers: List<TabController>
+        get() =
+            (0..<tabsView.tabCount).mapNotNull {
+                (tabsView.getComponentAt(it) as TabView).tabController
+            }
+
     init {
         tabsView.comboBox.addActionListener(this)
-        tabsView.getModel().addChangeListener(this)
-        val transformer = PreferenceService.PREFERENCES.get("transformer", null)
-        if (transformer != null) tabsView.comboBox.setSelectedItem(Transformer.valueOf(transformer))
-    }
-
-    override fun actionPerformed(event: ActionEvent?) {
-        PreferenceService.PREFERENCES.put("transformer", this.transformer?.name)
-        for (i in 0..<tabsView.tabCount) {
-            val controller: TabController? = (tabsView.getComponentAt(i) as TabView).tabController
-            if (controller?.fileModel?.type is ClassType) scope.launch { controller.update() }
+        tabsView.model.addChangeListener(this)
+        PreferenceService.preferences.get("transformer", null)?.let {
+            tabsView.comboBox.selectedItem = Transformer.valueOf(it)
         }
     }
 
+    override fun actionPerformed(event: ActionEvent?) {
+        PreferenceService.preferences.put("transformer", transformer?.name)
+        controllers
+            .filter { it.fileModel.type is ClassType }
+            .forEach { scope.launch { it.update() } }
+    }
+
     override fun stateChanged(changeEvent: ChangeEvent?) {
-        val fileCloseTab = get<FileCloseTab>(FileCloseTab::class.java)
-        fileCloseTab.setEnabled(tabsView.tabCount > 0)
+        fileCloseTab.isEnabled = tabsView.tabCount > 0
     }
 
     fun addTab(fileModel: FileModel) {
         val existing = getController(fileModel)
         if (existing != null) {
-            tabsView.setSelectedComponent(existing.tabView)
+            tabsView.selectedComponent = existing.tabView
             return
         }
 
@@ -59,7 +66,7 @@ class TabsController(
             controller.update()
             if (getController(fileModel) == null) {
                 tabsView.addTab(fileModel.name, icon, component)
-                tabsView.setSelectedComponent(component)
+                tabsView.selectedComponent = component
             }
         }
     }
@@ -72,14 +79,7 @@ class TabsController(
         tabsView.removeAll()
     }
 
-    private fun getController(fileModel: FileModel?): TabController? {
-        var controller: TabController? = null
-
-        for (i in 0..<tabsView.tabCount) {
-            val current: TabController? = (tabsView.getComponentAt(i) as TabView).tabController
-            if (fileModel === current?.fileModel) controller = current
-        }
-
-        return controller
+    private fun getController(fileModel: FileModel) = controllers.lastOrNull {
+        it.fileModel === fileModel
     }
 }

--- a/src/main/kotlin/moe/sota/decompiler/controllers/TreeController.kt
+++ b/src/main/kotlin/moe/sota/decompiler/controllers/TreeController.kt
@@ -1,6 +1,5 @@
 package moe.sota.decompiler.controllers
 
-import java.util.*
 import javax.swing.SwingUtilities
 import javax.swing.tree.DefaultMutableTreeNode
 import javax.swing.tree.DefaultTreeModel
@@ -12,7 +11,7 @@ import moe.sota.decompiler.views.TreeView
 class TreeController(private val treeView: TreeView) {
     fun setArchive(archiveModel: ArchiveModel) {
         val treeModel = treeView.tree.model as DefaultTreeModel
-        val rootNode = treeModel.getRoot() as DefaultMutableTreeNode
+        val rootNode = treeModel.root as DefaultMutableTreeNode
         val treeNode = createTreeNode(archiveModel)
         rootNode.removeAllChildren()
         rootNode.add(treeNode)
@@ -23,9 +22,8 @@ class TreeController(private val treeView: TreeView) {
 
     private fun createTreeNode(baseModel: BaseModel): DefaultMutableTreeNode {
         val treeNode = DefaultMutableTreeNode(baseModel)
-        val children = baseModel.children
-        Collections.sort(children)
-        for (child in children) treeNode.add(createTreeNode(child))
+        baseModel.children.sort()
+        for (child in baseModel.children) treeNode.add(createTreeNode(child))
         return treeNode
     }
 }

--- a/src/main/kotlin/moe/sota/decompiler/controllers/WindowController.kt
+++ b/src/main/kotlin/moe/sota/decompiler/controllers/WindowController.kt
@@ -12,7 +12,5 @@ class WindowController(private val windowView: WindowView) {
         windowView.validate()
     }
 
-    fun dispose() {
-        windowView.dispose()
-    }
+    fun dispose() = windowView.dispose()
 }

--- a/src/main/kotlin/moe/sota/decompiler/menus/file/FileCloseTab.kt
+++ b/src/main/kotlin/moe/sota/decompiler/menus/file/FileCloseTab.kt
@@ -11,7 +11,6 @@ import moe.sota.decompiler.services.LanguageService
 
 class FileCloseTab(languageService: LanguageService, private val tabsController: TabsController) :
     FlatMenuItem(), ActionListener {
-
     init {
         accelerator =
             KeyStroke.getKeyStroke(KeyEvent.VK_W, Toolkit.getDefaultToolkit().menuShortcutKeyMaskEx)

--- a/src/main/kotlin/moe/sota/decompiler/menus/file/FileNewInstance.kt
+++ b/src/main/kotlin/moe/sota/decompiler/menus/file/FileNewInstance.kt
@@ -13,7 +13,6 @@ class FileNewInstance(
     languageService: LanguageService,
     private val processService: ProcessService,
 ) : FlatMenuItem(), ActionListener {
-
     init {
         accelerator =
             KeyStroke.getKeyStroke(KeyEvent.VK_N, Toolkit.getDefaultToolkit().menuShortcutKeyMaskEx)

--- a/src/main/kotlin/moe/sota/decompiler/menus/file/FileOpenFile.kt
+++ b/src/main/kotlin/moe/sota/decompiler/menus/file/FileOpenFile.kt
@@ -38,6 +38,6 @@ class FileOpenFile(languageService: LanguageService) :
             }
 
         fileChooser.showOpenDialog(windowView)
-        if (fileChooser.selectedFile != null) LoaderService.load(fileChooser.selectedFile)
+        fileChooser.selectedFile?.let(LoaderService::load)
     }
 }

--- a/src/main/kotlin/moe/sota/decompiler/models/ArchiveModel.kt
+++ b/src/main/kotlin/moe/sota/decompiler/models/ArchiveModel.kt
@@ -2,6 +2,6 @@ package moe.sota.decompiler.models
 
 class ArchiveModel(path: String) : BaseModel(path, false) {
     init {
-        setIcon("icons/archive.png")
+        loadIcon("icons/archive.png")
     }
 }

--- a/src/main/kotlin/moe/sota/decompiler/models/BaseModel.kt
+++ b/src/main/kotlin/moe/sota/decompiler/models/BaseModel.kt
@@ -4,30 +4,24 @@ import java.awt.Image
 import java.awt.Toolkit
 
 abstract class BaseModel(val path: String, directory: Boolean) : Comparable<BaseModel> {
-    val children: MutableList<BaseModel> = ArrayList()
+    val children = mutableListOf<BaseModel>()
 
-    var name: String =
-        (if (directory) path.substring(0, path.length - 1) else path).let {
-            it.substring(it.lastIndexOf('/') + 1)
-        }
+    val name = (if (directory) path.dropLast(1) else path).substringAfterLast('/')
 
     var icon: Image? = null
         private set
 
-    fun setIcon(path: String) {
+    protected fun loadIcon(path: String) {
         icon =
             Toolkit.getDefaultToolkit()
-                .createImage(javaClass.classLoader.getResourceAsStream(path)!!.readAllBytes())
+                .createImage(javaClass.classLoader.getResourceAsStream(path)!!.readBytes())
     }
 
-    override fun compareTo(other: BaseModel): Int {
-        val class1 = javaClass
-        val class2 = other.javaClass
-        return when {
-            class1 == class2 -> name.compareTo(other.name, ignoreCase = true)
-            class1 == FileModel::class.java -> 1
-            class2 == FileModel::class.java -> -1
+    override fun compareTo(other: BaseModel): Int =
+        when {
+            javaClass == other.javaClass -> name.compareTo(other.name, ignoreCase = true)
+            this is FileModel -> 1
+            other is FileModel -> -1
             else -> 0
         }
-    }
 }

--- a/src/main/kotlin/moe/sota/decompiler/models/FileModel.kt
+++ b/src/main/kotlin/moe/sota/decompiler/models/FileModel.kt
@@ -13,5 +13,5 @@ class FileModel(private val jarFile: JarFile, private val jarEntry: JarEntry) :
     }
 
     val bytes: ByteArray
-        get() = jarFile.getInputStream(jarEntry).readBytes()
+        get() = jarFile.getInputStream(jarEntry).use { it.readBytes() }
 }

--- a/src/main/kotlin/moe/sota/decompiler/models/FileModel.kt
+++ b/src/main/kotlin/moe/sota/decompiler/models/FileModel.kt
@@ -3,16 +3,15 @@ package moe.sota.decompiler.models
 import java.util.jar.JarEntry
 import java.util.jar.JarFile
 import moe.sota.decompiler.services.TypeService
-import moe.sota.decompiler.types.Type
 
 class FileModel(private val jarFile: JarFile, private val jarEntry: JarEntry) :
     BaseModel(jarEntry.name, false) {
-    val type: Type? = TypeService.getType(this)
+    val type = TypeService.getType(this)
 
     init {
-        setIcon(type?.icon ?: "icons/file.png")
+        loadIcon(type?.icon ?: "icons/file.png")
     }
 
     val bytes: ByteArray
-        get() = jarFile.getInputStream(jarEntry).readAllBytes()
+        get() = jarFile.getInputStream(jarEntry).readBytes()
 }

--- a/src/main/kotlin/moe/sota/decompiler/models/PackageModel.kt
+++ b/src/main/kotlin/moe/sota/decompiler/models/PackageModel.kt
@@ -2,6 +2,6 @@ package moe.sota.decompiler.models
 
 class PackageModel(path: String) : BaseModel(path, true) {
     init {
-        setIcon("icons/package.png")
+        loadIcon("icons/package.png")
     }
 }

--- a/src/main/kotlin/moe/sota/decompiler/modules/ControllersModule.kt
+++ b/src/main/kotlin/moe/sota/decompiler/modules/ControllersModule.kt
@@ -1,6 +1,11 @@
 package moe.sota.decompiler.modules
 
-import moe.sota.decompiler.controllers.*
+import moe.sota.decompiler.controllers.AboutController
+import moe.sota.decompiler.controllers.StartController
+import moe.sota.decompiler.controllers.TabController
+import moe.sota.decompiler.controllers.TabsController
+import moe.sota.decompiler.controllers.TreeController
+import moe.sota.decompiler.controllers.WindowController
 import moe.sota.decompiler.models.FileModel
 import org.koin.core.module.dsl.singleOf
 import org.koin.core.parameter.parametersOf
@@ -8,8 +13,8 @@ import org.koin.dsl.module
 
 val controllersModule = module {
     singleOf(::AboutController)
-    singleOf(::TreeController)
     singleOf(::StartController)
+    singleOf(::TreeController)
     singleOf(::WindowController)
 
     single { TabsController(get()) { fileModel -> get { parametersOf(fileModel) } } }

--- a/src/main/kotlin/moe/sota/decompiler/modules/MenusModule.kt
+++ b/src/main/kotlin/moe/sota/decompiler/modules/MenusModule.kt
@@ -1,7 +1,11 @@
 package moe.sota.decompiler.modules
 
 import moe.sota.decompiler.menus.MenuBar
-import moe.sota.decompiler.menus.file.*
+import moe.sota.decompiler.menus.file.File
+import moe.sota.decompiler.menus.file.FileCloseTab
+import moe.sota.decompiler.menus.file.FileExit
+import moe.sota.decompiler.menus.file.FileNewInstance
+import moe.sota.decompiler.menus.file.FileOpenFile
 import moe.sota.decompiler.menus.help.Help
 import moe.sota.decompiler.menus.help.HelpAbout
 import org.koin.core.module.dsl.singleOf

--- a/src/main/kotlin/moe/sota/decompiler/modules/ViewsModule.kt
+++ b/src/main/kotlin/moe/sota/decompiler/modules/ViewsModule.kt
@@ -1,7 +1,12 @@
 package moe.sota.decompiler.modules
 
 import moe.sota.decompiler.models.FileModel
-import moe.sota.decompiler.views.*
+import moe.sota.decompiler.views.AboutView
+import moe.sota.decompiler.views.StartView
+import moe.sota.decompiler.views.TabView
+import moe.sota.decompiler.views.TabsView
+import moe.sota.decompiler.views.TreeView
+import moe.sota.decompiler.views.WindowView
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 

--- a/src/main/kotlin/moe/sota/decompiler/services/LanguageService.kt
+++ b/src/main/kotlin/moe/sota/decompiler/services/LanguageService.kt
@@ -1,11 +1,10 @@
 package moe.sota.decompiler.services
 
-import java.util.*
+import java.util.Locale
+import java.util.ResourceBundle
 
 class LanguageService {
     private val resourceBundle = ResourceBundle.getBundle("langs/language", Locale.getDefault())
 
-    fun getString(key: String): String {
-        return resourceBundle.getString(key)
-    }
+    fun getString(key: String): String = resourceBundle.getString(key)
 }

--- a/src/main/kotlin/moe/sota/decompiler/services/LoaderService.kt
+++ b/src/main/kotlin/moe/sota/decompiler/services/LoaderService.kt
@@ -16,36 +16,33 @@ import moe.sota.decompiler.models.FileModel
 import moe.sota.decompiler.models.PackageModel
 import moe.sota.decompiler.views.WindowView
 import org.koin.core.component.KoinComponent
-import org.koin.core.component.get
+import org.koin.core.component.inject
 
 object LoaderService : KoinComponent {
     private val scope = MainScope()
 
+    private val tabsController: TabsController by inject()
+    private val treeController: TreeController by inject()
+    private val windowController: WindowController by inject()
+    private val windowView: WindowView by inject()
+
     fun load(file: File) {
         scope.launch {
-            val tabsController = get<TabsController>()
-            val treeController = get<TreeController>()
-            val windowController = get<WindowController>()
-            val windowView = get<WindowView>()
-
-            setProgressState(windowView, Taskbar.State.INDETERMINATE)
+            setProgressState(Taskbar.State.INDETERMINATE)
 
             try {
                 val archive =
                     withContext(Dispatchers.IO) {
                         val jar = JarFile(file)
-                        val entries = jar.entries()
-                        val archive = ArchiveModel(file.name)
 
-                        while (entries.hasMoreElements()) {
-                            val entry = entries.nextElement()
-                            val packageModel = getChildByPath(archive, entry.name)
-                            if (entry.isDirectory)
-                                packageModel.children.add(PackageModel(entry.name))
-                            else packageModel.children.add(FileModel(jar, entry))
+                        ArchiveModel(file.name).apply {
+                            for (entry in jar.entries()) {
+                                val child =
+                                    if (entry.isDirectory) PackageModel(entry.name)
+                                    else FileModel(jar, entry)
+                                getChildByPath(this, entry.name).children.add(child)
+                            }
                         }
-
-                        archive
                     }
 
                 windowController.activate()
@@ -54,23 +51,21 @@ object LoaderService : KoinComponent {
             } catch (e: Exception) {
                 e.printStackTrace(System.err)
             } finally {
-                setProgressState(windowView, Taskbar.State.OFF)
+                setProgressState(Taskbar.State.OFF)
             }
         }
     }
 
-    private fun setProgressState(windowView: WindowView, state: Taskbar.State) {
-        if (
-            Taskbar.isTaskbarSupported() &&
-                Taskbar.getTaskbar().isSupported(Taskbar.Feature.PROGRESS_STATE_WINDOW)
-        )
-            Taskbar.getTaskbar().setWindowProgressState(windowView, state)
+    private fun setProgressState(state: Taskbar.State) {
+        if (!Taskbar.isTaskbarSupported()) return
+
+        val taskbar = Taskbar.getTaskbar()
+        if (taskbar.isSupported(Taskbar.Feature.PROGRESS_STATE_WINDOW))
+            taskbar.setWindowProgressState(windowView, state)
     }
 
-    private fun getChildByPath(baseModel: BaseModel, path: String): BaseModel {
-        for (child in baseModel.children) if (child is PackageModel && path.startsWith(child.path))
-            return getChildByPath(child, path)
-
-        return baseModel
-    }
+    private fun getChildByPath(baseModel: BaseModel, path: String): BaseModel =
+        baseModel.children
+            .firstOrNull { it is PackageModel && path.startsWith(it.path) }
+            ?.let { getChildByPath(it, path) } ?: baseModel
 }

--- a/src/main/kotlin/moe/sota/decompiler/services/PreferenceService.kt
+++ b/src/main/kotlin/moe/sota/decompiler/services/PreferenceService.kt
@@ -4,5 +4,5 @@ import java.util.prefs.Preferences
 import moe.sota.decompiler.Application
 
 object PreferenceService {
-    val PREFERENCES: Preferences = Preferences.userNodeForPackage(Application::class.java)
+    val preferences = Preferences.userNodeForPackage(Application::class.java)
 }

--- a/src/main/kotlin/moe/sota/decompiler/services/ProcessService.kt
+++ b/src/main/kotlin/moe/sota/decompiler/services/ProcessService.kt
@@ -8,8 +8,8 @@ import moe.sota.decompiler.main
 class ProcessService {
     fun start() {
         val java = ProcessHandle.current().info().command().getOrNull() ?: return
+        val mainClass = ::main.javaMethod?.declaringClass?.canonicalName ?: return
         val classPath = ManagementFactory.getRuntimeMXBean().classPath
-        val mainClass = ::main.javaMethod?.declaringClass?.canonicalName
         ProcessBuilder(java, "-cp", classPath, mainClass).start()
     }
 }

--- a/src/main/kotlin/moe/sota/decompiler/services/ProcessService.kt
+++ b/src/main/kotlin/moe/sota/decompiler/services/ProcessService.kt
@@ -1,16 +1,15 @@
 package moe.sota.decompiler.services
 
 import java.lang.management.ManagementFactory
+import kotlin.jvm.optionals.getOrNull
 import kotlin.reflect.jvm.javaMethod
 import moe.sota.decompiler.main
 
 class ProcessService {
     fun start() {
-        val java = ProcessHandle.current().info().command()
-        if (java.isPresent) {
-            val classPath: String? = ManagementFactory.getRuntimeMXBean().classPath
-            val main = ::main.javaMethod?.declaringClass?.canonicalName
-            ProcessBuilder(java.get(), "-cp", classPath, main).start()
-        }
+        val java = ProcessHandle.current().info().command().getOrNull() ?: return
+        val classPath = ManagementFactory.getRuntimeMXBean().classPath
+        val mainClass = ::main.javaMethod?.declaringClass?.canonicalName
+        ProcessBuilder(java, "-cp", classPath, mainClass).start()
     }
 }

--- a/src/main/kotlin/moe/sota/decompiler/services/SearchService.kt
+++ b/src/main/kotlin/moe/sota/decompiler/services/SearchService.kt
@@ -6,8 +6,6 @@ import org.ktorm.database.Database
 class SearchService {
     private val database = Database.connect("jdbc:h2:mem:")
 
-    init {}
-
     fun load(jar: JarFile) {}
 
     fun dispose() {}

--- a/src/main/kotlin/moe/sota/decompiler/services/TypeService.kt
+++ b/src/main/kotlin/moe/sota/decompiler/services/TypeService.kt
@@ -7,7 +7,7 @@ import moe.sota.decompiler.types.ManifestType
 import moe.sota.decompiler.types.Type
 
 object TypeService {
-    private val TYPES = listOf(ClassType(), ImageType(), ManifestType())
+    private val types = listOf(ClassType, ImageType, ManifestType)
 
-    fun getType(fileModel: FileModel): Type? = TYPES.firstOrNull { it.isFormat(fileModel) }
+    fun getType(fileModel: FileModel): Type? = types.firstOrNull { it.isFormat(fileModel) }
 }

--- a/src/main/kotlin/moe/sota/decompiler/transformers/CFRTransformer.kt
+++ b/src/main/kotlin/moe/sota/decompiler/transformers/CFRTransformer.kt
@@ -10,22 +10,19 @@ import org.benf.cfr.reader.api.OutputSinkFactory.SinkType
 import org.benf.cfr.reader.bytecode.analysis.parse.utils.Pair
 import org.benf.cfr.reader.util.getopt.OptionsImpl
 
-class CFRTransformer :
-    ITransformer, ClassFileSource, OutputSinkFactory, OutputSinkFactory.Sink<String> {
+class CFRTransformer : ITransformer, ClassFileSource, OutputSinkFactory, Sink<String> {
     private lateinit var fileModel: FileModel
     private lateinit var output: String
 
     override fun transform(fileModel: FileModel): String {
         this.fileModel = fileModel
-        val driver =
-            CfrDriver.Builder()
-                .withClassFileSource(this)
-                .withOptions(OPTIONS)
-                .withOutputSink(this)
-                .build()
-        driver.analyse(listOf(fileModel.path))
-        if (output.startsWith("/")) output = output.substring(31)
-        return output
+        CfrDriver.Builder()
+            .withClassFileSource(this)
+            .withOptions(OPTIONS)
+            .withOutputSink(this)
+            .build()
+            .analyse(listOf(fileModel.path))
+        return if (output.startsWith("/")) output.substring(31) else output
     }
 
     override fun getClassFileContent(path: String): Pair<ByteArray, String> =
@@ -52,10 +49,10 @@ class CFRTransformer :
     companion object {
         private val OPTIONS =
             mapOf(
-                OptionsImpl.DECOMPILE_INNER_CLASSES.name to false.toString(),
-                OptionsImpl.RELINK_CONSTANT_STRINGS.name to false.toString(),
-                OptionsImpl.REMOVE_INNER_CLASS_SYNTHETICS.name to false.toString(),
-                OptionsImpl.SHOW_CFR_VERSION.name to false.toString(),
+                OptionsImpl.DECOMPILE_INNER_CLASSES.name to "false",
+                OptionsImpl.RELINK_CONSTANT_STRINGS.name to "false",
+                OptionsImpl.REMOVE_INNER_CLASS_SYNTHETICS.name to "false",
+                OptionsImpl.SHOW_CFR_VERSION.name to "false",
             )
     }
 }

--- a/src/main/kotlin/moe/sota/decompiler/transformers/JDTransformer.kt
+++ b/src/main/kotlin/moe/sota/decompiler/transformers/JDTransformer.kt
@@ -13,12 +13,11 @@ class JDTransformer : ITransformer, Loader, Printer {
     override fun transform(fileModel: FileModel): String {
         this.fileModel = fileModel
         builder = StringBuilder()
-        if (fileModel.path.contains("/")) {
-            val pkg = fileModel.path.substring(0, fileModel.path.lastIndexOf('/')).replace('/', '.')
+        if ('/' in fileModel.path) {
+            val pkg = fileModel.path.substringBeforeLast('/').replace('/', '.')
             builder.append("package $pkg;\n\n")
         }
-        val decompiler = ClassFileToJavaSourceDecompiler()
-        decompiler.decompile(this, this, "")
+        ClassFileToJavaSourceDecompiler().decompile(this, this, "")
         return builder.toString()
     }
 

--- a/src/main/kotlin/moe/sota/decompiler/transformers/VineflowerTransformer.kt
+++ b/src/main/kotlin/moe/sota/decompiler/transformers/VineflowerTransformer.kt
@@ -16,9 +16,10 @@ class VineflowerTransformer : IFernflowerLogger(), ITransformer, IBytecodeProvid
     override fun transform(fileModel: FileModel): String {
         this.fileModel = fileModel
         // TODO: Refactor
-        val fernflower = Fernflower(this, this, IFernflowerPreferences.getDefaults(), this)
-        fernflower.addSource(File(".class"))
-        fernflower.decompileContext()
+        Fernflower(this, this, IFernflowerPreferences.getDefaults(), this).apply {
+            addSource(File(".class"))
+            decompileContext()
+        }
         return content.replace("   ", "    ")
     }
 

--- a/src/main/kotlin/moe/sota/decompiler/types/ClassType.kt
+++ b/src/main/kotlin/moe/sota/decompiler/types/ClassType.kt
@@ -3,7 +3,7 @@ package moe.sota.decompiler.types
 import moe.sota.decompiler.models.FileModel
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants
 
-class ClassType : Type("icons/class.png", SyntaxConstants.SYNTAX_STYLE_JAVA) {
+object ClassType : Type("icons/class.png", SyntaxConstants.SYNTAX_STYLE_JAVA) {
     override fun isFormat(fileModel: FileModel): Boolean =
-        fileModel.name.lowercase().endsWith(".class")
+        fileModel.name.endsWith(".class", ignoreCase = true)
 }

--- a/src/main/kotlin/moe/sota/decompiler/types/ImageType.kt
+++ b/src/main/kotlin/moe/sota/decompiler/types/ImageType.kt
@@ -2,12 +2,10 @@ package moe.sota.decompiler.types
 
 import moe.sota.decompiler.models.FileModel
 
-class ImageType : Type("icons/image.png", null) {
-    override fun isFormat(fileModel: FileModel): Boolean =
-        fileModel.name.lowercase().let {
-            return it.endsWith(".png") ||
-                it.endsWith(".jpg") ||
-                it.endsWith(".jpeg") ||
-                it.endsWith(".gif")
-        }
+object ImageType : Type("icons/image.png", null) {
+    private val extensions = listOf(".png", ".jpg", ".jpeg", ".gif")
+
+    override fun isFormat(fileModel: FileModel): Boolean = extensions.any {
+        fileModel.name.endsWith(it, ignoreCase = true)
+    }
 }

--- a/src/main/kotlin/moe/sota/decompiler/types/ManifestType.kt
+++ b/src/main/kotlin/moe/sota/decompiler/types/ManifestType.kt
@@ -3,7 +3,7 @@ package moe.sota.decompiler.types
 import moe.sota.decompiler.models.FileModel
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants
 
-class ManifestType : Type("icons/manifest.png", SyntaxConstants.SYNTAX_STYLE_PROPERTIES_FILE) {
+object ManifestType : Type("icons/manifest.png", SyntaxConstants.SYNTAX_STYLE_PROPERTIES_FILE) {
     override fun isFormat(fileModel: FileModel): Boolean =
-        fileModel.name.lowercase().endsWith(".mf")
+        fileModel.name.endsWith(".mf", ignoreCase = true)
 }

--- a/src/main/kotlin/moe/sota/decompiler/views/AboutView.kt
+++ b/src/main/kotlin/moe/sota/decompiler/views/AboutView.kt
@@ -10,107 +10,88 @@ import java.awt.event.ActionEvent
 import java.lang.management.ManagementFactory
 import java.net.URI
 import java.time.Year
-import java.util.*
-import javax.swing.*
+import java.util.Properties
+import javax.swing.BorderFactory
+import javax.swing.Box
+import javax.swing.BoxLayout
+import javax.swing.ImageIcon
+import javax.swing.JDialog
+import javax.swing.JLabel
+import javax.swing.JPanel
 import javax.swing.border.EmptyBorder
 import moe.sota.decompiler.services.LanguageService
 import net.miginfocom.swing.MigLayout
 
 class AboutView(languageService: LanguageService, windowView: WindowView) : JDialog(windowView) {
-    val root: JPanel
-    val content: JPanel
-    val logo: FlatLabel
-    val header: FlatLabel
-    val copyright: FlatLabel
-    val version: FlatLabel
-    val vm: JPanel
-    val vmName: FlatLabel
-    val vmVendor: FlatLabel
-    val vmVersion: FlatLabel
-    val controls: JPanel
-    val github: FlatButton
-    val ok: FlatButton
-
     init {
         isModal = true
         isResizable = false
         title = languageService.getString("about")
-        getRootPane().putClientProperty(FlatClientProperties.TITLE_BAR_SHOW_ICON, false)
+        rootPane.putClientProperty(FlatClientProperties.TITLE_BAR_SHOW_ICON, false)
 
-        root =
+        val root =
             JPanel().apply {
                 border = EmptyBorder(16, 16, 16, 16)
                 layout = BorderLayout()
             }
         contentPane = root
 
-        content =
+        val content =
             JPanel().apply {
                 border = EmptyBorder(0, 0, 16, 0)
                 layout = MigLayout()
             }
         root.add(content, BorderLayout.CENTER)
 
-        logo =
+        val logo =
             FlatLabel().apply {
                 border = EmptyBorder(0, 0, 0, 16)
-                icon =
-                    ImageIcon(
-                        owner.getIconImages()[0].getScaledInstance(64, 64, Image.SCALE_SMOOTH)
-                    )
+                icon = ImageIcon(owner.iconImages[0].getScaledInstance(64, 64, Image.SCALE_SMOOTH))
                 verticalAlignment = JLabel.TOP
             }
         content.add(logo, "dock west")
 
-        header =
+        val header =
             FlatLabel().apply {
                 styleClass = "h1"
                 text = "Decompiler"
             }
         content.add(header, "wrap")
 
-        version =
+        val version =
             FlatLabel().apply {
                 val properties = Properties()
                 properties.load(javaClass.classLoader.getResourceAsStream("application.properties"))
                 text =
-                    String.format(
-                        languageService.getString("about.version"),
-                        properties.getProperty("version"),
-                    )
+                    languageService
+                        .getString("about.version")
+                        .format(properties.getProperty("version"))
             }
         content.add(version, "wrap")
 
-        copyright =
-            FlatLabel().apply {
-                text = String.format("\u00a9 2022 - %s S\u014Dta", Year.now().value)
-            }
+        val copyright = FlatLabel().apply { text = "© 2022 - ${Year.now().value} Sōta" }
         content.add(copyright, "wrap")
 
-        vm =
+        val vm =
             JPanel().apply {
                 border = BorderFactory.createTitledBorder(languageService.getString("about.vm"))
                 layout = MigLayout()
             }
         content.add(vm, "wrap, gapy 16px")
 
-        vmName = FlatLabel().apply { text = ManagementFactory.getRuntimeMXBean().vmName }
-        vm.add(vmName, "wrap")
+        val runtime = ManagementFactory.getRuntimeMXBean()
+        vm.add(FlatLabel().apply { text = runtime.vmName }, "wrap")
+        vm.add(FlatLabel().apply { text = runtime.vmVendor }, "wrap")
+        vm.add(FlatLabel().apply { text = runtime.vmVersion }, "wrap")
 
-        vmVendor = FlatLabel().apply { text = ManagementFactory.getRuntimeMXBean().vmVendor }
-        vm.add(vmVendor, "wrap")
-
-        vmVersion = FlatLabel().apply { text = ManagementFactory.getRuntimeMXBean().vmVersion }
-        vm.add(vmVersion, "wrap")
-
-        controls =
+        val controls =
             JPanel().apply {
                 layout = BoxLayout(this, BoxLayout.X_AXIS)
                 add(Box.createHorizontalGlue())
             }
         root.add(controls, BorderLayout.SOUTH)
 
-        github =
+        val github =
             FlatButton().apply {
                 isFocusable = false
                 text = "GitHub"
@@ -120,24 +101,22 @@ class AboutView(languageService: LanguageService, windowView: WindowView) : JDia
 
         controls.add(Box.createHorizontalStrut(8))
 
-        ok =
+        val ok =
             FlatButton().apply {
                 text = languageService.getString("about.ok")
                 addActionListener(::onOkAction)
             }
         controls.add(ok)
-        getRootPane().setDefaultButton(ok)
+        rootPane.defaultButton = ok
 
         pack()
         setLocationRelativeTo(owner)
     }
 
-    private fun onGitHubAction(event: ActionEvent?) {
+    private fun onGitHubAction(event: ActionEvent) {
         if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE))
             Desktop.getDesktop().browse(URI("https://github.com/sotasan/decompiler"))
     }
 
-    private fun onOkAction(event: ActionEvent?) {
-        dispose()
-    }
+    private fun onOkAction(event: ActionEvent) = dispose()
 }

--- a/src/main/kotlin/moe/sota/decompiler/views/StartView.kt
+++ b/src/main/kotlin/moe/sota/decompiler/views/StartView.kt
@@ -8,38 +8,31 @@ import moe.sota.decompiler.services.LanguageService
 import net.miginfocom.swing.MigLayout
 
 class StartView(languageService: LanguageService) : JPanel() {
-    private val root: JPanel
-    private val header: FlatLabel
-    private val open: FlatLabel
-    private val drag: FlatLabel
-
     init {
         layout = MigLayout("fill")
 
-        root = JPanel().apply { layout = MigLayout("gapy 15") }
+        val root = JPanel().apply { layout = MigLayout("gapy 15") }
         add(root, "center")
 
-        header =
+        val header =
             FlatLabel().apply {
                 styleClass = "h1"
                 text = languageService.getString("empty")
             }
         root.add(header, "wrap")
 
-        open =
+        val open =
             FlatLabel().apply {
                 val group = languageService.getString("file")
                 val item = languageService.getString("file.openFile")
                 val modifier =
-                    KeyEvent.getModifiersExText(
-                        Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()
-                    )
+                    KeyEvent.getModifiersExText(Toolkit.getDefaultToolkit().menuShortcutKeyMaskEx)
                 val key = KeyEvent.getKeyText(KeyEvent.VK_O)
                 text = "$group > $item ($modifier + $key)"
             }
         root.add(open, "wrap")
 
-        drag = FlatLabel().apply { text = languageService.getString("empty.drag") }
+        val drag = FlatLabel().apply { text = languageService.getString("empty.drag") }
         root.add(drag, "wrap")
     }
 }

--- a/src/main/kotlin/moe/sota/decompiler/views/TabView.kt
+++ b/src/main/kotlin/moe/sota/decompiler/views/TabView.kt
@@ -8,81 +8,86 @@ import java.awt.event.ComponentAdapter
 import java.awt.event.ComponentEvent
 import java.awt.event.MouseWheelEvent
 import java.awt.event.MouseWheelListener
-import javax.swing.*
-import kotlin.math.max
-import kotlin.math.min
+import javax.swing.BorderFactory
+import javax.swing.ImageIcon
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.JScrollPane
 import moe.sota.decompiler.controllers.TabController
 import moe.sota.decompiler.models.FileModel
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea
 import org.fife.ui.rsyntaxtextarea.Theme
 import org.fife.ui.rtextarea.RTextScrollPane
 
-class TabView(val fileModel: FileModel) : JPanel(), MouseWheelListener {
+class TabView(private val fileModel: FileModel) : JPanel(), MouseWheelListener {
     val textArea: RSyntaxTextArea
     val scrollPane: RTextScrollPane
     var tabController: TabController? = null
 
     init {
-        setLayout(BorderLayout())
+        layout = BorderLayout()
 
         val theme = Theme.load(javaClass.classLoader.getResourceAsStream("themes/RSyntaxTheme.xml"))
 
         textArea = RSyntaxTextArea()
         theme.apply(textArea)
-        textArea.addMouseWheelListener(this)
-        textArea.isBracketMatchingEnabled = false
-        textArea.setCursor(Cursor(Cursor.TEXT_CURSOR))
-        textArea.setDropTarget(null)
-        textArea.isEditable = false
-        textArea.highlightCurrentLine = false
+        textArea.apply {
+            addMouseWheelListener(this@TabView)
+            isBracketMatchingEnabled = false
+            cursor = Cursor(Cursor.TEXT_CURSOR)
+            dropTarget = null
+            isEditable = false
+            highlightCurrentLine = false
+        }
 
         scrollPane = RTextScrollPane(textArea)
         theme.apply(textArea)
-        scrollPane.setBorder(BorderFactory.createEmptyBorder())
+        scrollPane.border = BorderFactory.createEmptyBorder()
         add(scrollPane)
 
-        setFontSize((getFont().getSize() + 2).toFloat())
+        setFontSize(font.size + 2f)
     }
 
     // TODO: global font size
     override fun mouseWheelMoved(event: MouseWheelEvent) {
         if (event.isControlDown || event.isMetaDown)
-            setFontSize(
-                min(50, max(10, textArea.getFont().getSize() - event.getWheelRotation())).toFloat()
-            )
-        else for (listener in scrollPane.mouseWheelListeners) listener.mouseWheelMoved(event)
+            setFontSize((textArea.font.size - event.wheelRotation).coerceIn(10, 50).toFloat())
+        else scrollPane.mouseWheelListeners.forEach { it.mouseWheelMoved(event) }
     }
 
     private fun setFontSize(size: Float) {
-        val font = textArea.getFont().deriveFont(size)
-        textArea.setFont(font)
-        scrollPane.gutter.setLineNumberFont(font)
+        val font = textArea.font.deriveFont(size)
+        textArea.font = font
+        scrollPane.gutter.lineNumberFont = font
     }
 
-    fun setScrollPane(imageScrollPane: JScrollPane) {
-        setLayout(BorderLayout())
+    fun showImage() {
+        layout = BorderLayout()
         removeAll()
 
-        val imageLabel = JLabel()
+        val imageScrollPane = JScrollPane()
         val originalIcon = ImageIcon(fileModel.bytes)
-        imageLabel.setIcon(originalIcon)
-        imageLabel.setHorizontalAlignment(JLabel.CENTER)
-        imageLabel.setVerticalAlignment(JLabel.CENTER)
+        val imageLabel =
+            JLabel().apply {
+                icon = originalIcon
+                horizontalAlignment = JLabel.CENTER
+                verticalAlignment = JLabel.CENTER
+            }
 
         imageScrollPane.setViewportView(imageLabel)
-        imageScrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER)
-        imageScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_NEVER)
+        imageScrollPane.horizontalScrollBarPolicy = JScrollPane.HORIZONTAL_SCROLLBAR_NEVER
+        imageScrollPane.verticalScrollBarPolicy = JScrollPane.VERTICAL_SCROLLBAR_NEVER
 
         imageScrollPane.addComponentListener(
             object : ComponentAdapter() {
-                override fun componentResized(e: ComponentEvent?) {
-                    var height = getHeight()
+                override fun componentResized(event: ComponentEvent) {
+                    var height = this@TabView.height
                     var width =
                         (originalIcon.iconWidth * (height.toDouble() / originalIcon.iconHeight))
                             .toInt()
 
-                    if (width > getWidth()) {
-                        width = getWidth()
+                    if (width > this@TabView.width) {
+                        width = this@TabView.width
                         height =
                             (originalIcon.iconHeight * (width.toDouble() / originalIcon.iconWidth))
                                 .toInt()
@@ -90,14 +95,17 @@ class TabView(val fileModel: FileModel) : JPanel(), MouseWheelListener {
 
                     // Verify if the image is bigger than the scroll pane
                     if (originalIcon.iconWidth > width || originalIcon.iconHeight > height) {
-                        val scaledImage =
-                            originalIcon
-                                .getImage()
-                                .getScaledInstance(width, height, Image.SCALE_SMOOTH)
-                        imageLabel.setIcon(ImageIcon(scaledImage))
+                        imageLabel.icon =
+                            ImageIcon(
+                                originalIcon.image.getScaledInstance(
+                                    width,
+                                    height,
+                                    Image.SCALE_SMOOTH,
+                                )
+                            )
                         imageLabel.preferredSize = Dimension(width, height)
                     } else {
-                        imageLabel.setIcon(originalIcon)
+                        imageLabel.icon = originalIcon
                         imageLabel.preferredSize =
                             Dimension(originalIcon.iconWidth, originalIcon.iconHeight)
                     }

--- a/src/main/kotlin/moe/sota/decompiler/views/TabsView.kt
+++ b/src/main/kotlin/moe/sota/decompiler/views/TabsView.kt
@@ -9,12 +9,10 @@ import java.awt.event.MouseEvent
 import javax.swing.BorderFactory
 import javax.swing.Box
 import javax.swing.DefaultComboBoxModel
-import javax.swing.JTabbedPane
 import moe.sota.decompiler.transformers.Transformer
 
 class TabsView : FlatTabbedPane() {
     val comboBox: FlatComboBox<Transformer>
-    val toolBar: FlatToolBar
 
     init {
         isHasFullBorder = true
@@ -23,9 +21,9 @@ class TabsView : FlatTabbedPane() {
         tabLayoutPolicy = SCROLL_TAB_LAYOUT
         tabType = TabType.card
         addMouseListener(TabMouseAdapter())
-        setTabCloseCallback(::onTabClose)
+        setTabCloseCallback { _, tabIndex -> remove(tabIndex) }
 
-        toolBar =
+        val toolBar =
             FlatToolBar().apply {
                 border = BorderFactory.createEmptyBorder(0, 5, 0, 5)
                 add(Box.createHorizontalGlue())
@@ -37,15 +35,11 @@ class TabsView : FlatTabbedPane() {
                 val dimension = Dimension(150, 25)
                 isFocusable = false
                 maximumSize = dimension
-                model = DefaultComboBoxModel<Transformer>(Transformer.entries.toTypedArray())
+                model = DefaultComboBoxModel(Transformer.entries.toTypedArray())
                 preferredSize = dimension
                 selectedItem = Transformer.Vineflower
             }
         toolBar.add(comboBox)
-    }
-
-    private fun onTabClose(tabPane: JTabbedPane?, tabIndex: Int) {
-        remove(tabIndex)
     }
 }
 
@@ -53,13 +47,12 @@ private class TabMouseAdapter : MouseAdapter() {
     private var index = 0
 
     override fun mousePressed(event: MouseEvent) {
-        val tabbedPane = event.getSource() as FlatTabbedPane
-        if (event.getButton() == MouseEvent.BUTTON2)
-            index = tabbedPane.indexAtLocation(event.getX(), event.getY())
+        val tabbedPane = event.source as FlatTabbedPane
+        if (event.button == MouseEvent.BUTTON2) index = tabbedPane.indexAtLocation(event.x, event.y)
     }
 
     override fun mouseReleased(event: MouseEvent) {
-        val tabbedPane = event.getSource() as FlatTabbedPane
-        if (event.getButton() == MouseEvent.BUTTON2 && index != -1) tabbedPane.remove(index)
+        if (event.button == MouseEvent.BUTTON2 && index != -1)
+            (event.source as FlatTabbedPane).remove(index)
     }
 }

--- a/src/main/kotlin/moe/sota/decompiler/views/TreeView.kt
+++ b/src/main/kotlin/moe/sota/decompiler/views/TreeView.kt
@@ -4,8 +4,16 @@ import com.formdev.flatlaf.extras.components.FlatScrollPane
 import com.formdev.flatlaf.extras.components.FlatTree
 import java.awt.BorderLayout
 import java.awt.Component
-import java.awt.event.*
-import javax.swing.*
+import java.awt.event.InputEvent
+import java.awt.event.KeyAdapter
+import java.awt.event.KeyEvent
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import javax.swing.BorderFactory
+import javax.swing.ImageIcon
+import javax.swing.JPanel
+import javax.swing.JTree
+import javax.swing.ToolTipManager
 import javax.swing.tree.DefaultMutableTreeNode
 import javax.swing.tree.DefaultTreeCellRenderer
 import javax.swing.tree.DefaultTreeModel
@@ -15,35 +23,32 @@ import moe.sota.decompiler.models.BaseModel
 import moe.sota.decompiler.models.FileModel
 
 class TreeView(private val tabsController: TabsController) : JPanel(BorderLayout()) {
-    val tree: FlatTree
-    val scrollPane: FlatScrollPane
+    // TODO: only one root node
+    val tree =
+        FlatTree().apply {
+            addKeyListener(TreeKeyListener(this@TreeView))
+            addMouseListener(TreeMouseAdapter(this@TreeView))
+            selectionModel.selectionMode = TreeSelectionModel.SINGLE_TREE_SELECTION
+            cellRenderer = TreeCellRenderer()
+            model = DefaultTreeModel(DefaultMutableTreeNode())
+            isRootVisible = false
+            showsRootHandles = true
+        }
 
     init {
-        // TODO: only one root node
-        tree = FlatTree()
-        tree.addKeyListener(TreeKeyListener(this))
-        tree.addMouseListener(TreeMouseAdapter(this))
-        tree.getSelectionModel().selectionMode = TreeSelectionModel.SINGLE_TREE_SELECTION
-        tree.setCellRenderer(TreeCellRenderer())
-        tree.setModel(DefaultTreeModel(DefaultMutableTreeNode()))
-        tree.setRootVisible(false)
-        tree.setShowsRootHandles(true)
         ToolTipManager.sharedInstance().registerComponent(tree)
 
-        scrollPane = FlatScrollPane()
-        scrollPane.setBorder(BorderFactory.createEmptyBorder())
-        scrollPane.setViewportView(tree)
+        val scrollPane =
+            FlatScrollPane().apply {
+                border = BorderFactory.createEmptyBorder()
+                setViewportView(tree)
+            }
         add(scrollPane)
     }
 
     fun addTab(event: InputEvent) {
-        val path = (event.getSource() as JTree).selectionPath
-        if (path == null) return
-
-        val node = path.lastPathComponent as DefaultMutableTreeNode
-        if (node.getUserObject() == null) return
-
-        val model = node.getUserObject() as BaseModel?
+        val path = (event.source as JTree).selectionPath ?: return
+        val model = (path.lastPathComponent as DefaultMutableTreeNode).userObject
         if (model is FileModel) tabsController.addTab(model)
     }
 }
@@ -60,31 +65,24 @@ private class TreeCellRenderer : DefaultTreeCellRenderer() {
     ): Component? {
         val component =
             super.getTreeCellRendererComponent(tree, value, selected, expanded, leaf, row, focused)
-        val node = value as DefaultMutableTreeNode
-        if (node.getUserObject() is BaseModel) {
-            val model = node.getUserObject() as BaseModel
-            setText(model.name)
-            setIcon(ImageIcon(model.icon))
-            setToolTipText(model.name)
+        val model = (value as DefaultMutableTreeNode).userObject
+        if (model is BaseModel) {
+            text = model.name
+            icon = ImageIcon(model.icon)
+            toolTipText = model.name
         }
         return component
     }
 }
 
 private class TreeMouseAdapter(private val treeView: TreeView) : MouseAdapter() {
-
     override fun mousePressed(event: MouseEvent) {
-        if (event.getClickCount() % 2 == 0) treeView.addTab(event)
+        if (event.clickCount % 2 == 0) treeView.addTab(event)
     }
 }
 
-private class TreeKeyListener(private val treeView: TreeView) : KeyListener {
-
+private class TreeKeyListener(private val treeView: TreeView) : KeyAdapter() {
     override fun keyPressed(keyEvent: KeyEvent) {
         if (keyEvent.extendedKeyCode == KeyEvent.VK_ENTER) treeView.addTab(keyEvent)
     }
-
-    override fun keyReleased(keyEvent: KeyEvent?) {}
-
-    override fun keyTyped(keyEvent: KeyEvent?) {}
 }

--- a/src/main/kotlin/moe/sota/decompiler/views/WindowView.kt
+++ b/src/main/kotlin/moe/sota/decompiler/views/WindowView.kt
@@ -14,7 +14,6 @@ import java.awt.dnd.DropTargetDropEvent
 import java.awt.event.ComponentAdapter
 import java.awt.event.ComponentEvent
 import java.io.File
-import java.util.Locale
 import javax.swing.BoxLayout
 import javax.swing.JFrame
 import javax.swing.JPanel
@@ -106,9 +105,8 @@ private class WindowDropTarget : DropTarget() {
 
         val files = event.transferable.getTransferData(DataFlavor.javaFileListFlavor) as List<*>
         val file = files.firstOrNull() as File? ?: return
-        val name = file.name.lowercase(Locale.getDefault())
 
-        if (name.endsWith(".jar") || name.endsWith(".war") || name.endsWith(".zip")) {
+        if (listOf(".jar", ".war", ".zip").any { file.name.endsWith(it, ignoreCase = true) }) {
             LoaderService.load(file)
             event.dropComplete(true)
         }

--- a/src/main/kotlin/moe/sota/decompiler/views/WindowView.kt
+++ b/src/main/kotlin/moe/sota/decompiler/views/WindowView.kt
@@ -14,7 +14,7 @@ import java.awt.dnd.DropTargetDropEvent
 import java.awt.event.ComponentAdapter
 import java.awt.event.ComponentEvent
 import java.io.File
-import java.util.*
+import java.util.Locale
 import javax.swing.BoxLayout
 import javax.swing.JFrame
 import javax.swing.JPanel
@@ -25,7 +25,7 @@ import moe.sota.decompiler.services.LoaderService
 class WindowView(menuBar: MenuBar, startView: StartView, tabsView: TabsView, treeView: TreeView) :
     JFrame() {
     val splitPane: FlatSplitPane
-    var macos: JPanel? = null
+    internal var macos: JPanel? = null
 
     init {
         contentPane = startView
@@ -43,7 +43,7 @@ class WindowView(menuBar: MenuBar, startView: StartView, tabsView: TabsView, tre
             Taskbar.isTaskbarSupported() &&
                 Taskbar.getTaskbar().isSupported(Taskbar.Feature.ICON_IMAGE)
         )
-            Taskbar.getTaskbar().setIconImage(image)
+            Taskbar.getTaskbar().iconImage = image
         iconImage = image
 
         splitPane =
@@ -57,12 +57,12 @@ class WindowView(menuBar: MenuBar, startView: StartView, tabsView: TabsView, tre
                 layout = BoxLayout(this, BoxLayout.Y_AXIS)
                 minimumSize = Dimension(100, 0)
             }
-        splitPane.setLeftComponent(panel)
+        splitPane.leftComponent = panel
 
         if (SystemInfo.isMacFullWindowContentSupported) {
-            getRootPane().putClientProperty("apple.awt.fullWindowContent", true)
-            getRootPane().putClientProperty("apple.awt.transparentTitleBar", true)
-            getRootPane().putClientProperty("apple.awt.windowTitleVisible", false)
+            rootPane.putClientProperty("apple.awt.fullWindowContent", true)
+            rootPane.putClientProperty("apple.awt.transparentTitleBar", true)
+            rootPane.putClientProperty("apple.awt.windowTitleVisible", false)
 
             macos =
                 JPanel().apply {
@@ -86,7 +86,7 @@ class WindowView(menuBar: MenuBar, startView: StartView, tabsView: TabsView, tre
 }
 
 private class WindowComponentAdapter(private val windowView: WindowView) : ComponentAdapter() {
-    override fun componentResized(event: ComponentEvent?) {
+    override fun componentResized(event: ComponentEvent) {
         if (SystemInfo.isMacOS && windowView.macos != null)
             windowView.isVisible =
                 windowView.height <
@@ -102,19 +102,15 @@ private class WindowDropTarget : DropTarget() {
     override fun drop(event: DropTargetDropEvent) {
         event.acceptDrop(DnDConstants.ACTION_MOVE)
 
-        if (event.isDataFlavorSupported(DataFlavor.javaFileListFlavor)) {
-            val files =
-                event.transferable.getTransferData(DataFlavor.javaFileListFlavor) as MutableList<*>
+        if (!event.isDataFlavorSupported(DataFlavor.javaFileListFlavor)) return
 
-            if (!files.isEmpty()) {
-                val file = files[0] as File
-                val name = file.getName().lowercase(Locale.getDefault())
+        val files = event.transferable.getTransferData(DataFlavor.javaFileListFlavor) as List<*>
+        val file = files.firstOrNull() as File? ?: return
+        val name = file.name.lowercase(Locale.getDefault())
 
-                if (name.endsWith(".jar") || name.endsWith(".war") || name.endsWith(".zip")) {
-                    LoaderService.load(file)
-                    event.dropComplete(true)
-                }
-            }
+        if (name.endsWith(".jar") || name.endsWith(".war") || name.endsWith(".zip")) {
+            LoaderService.load(file)
+            event.dropComplete(true)
         }
     }
 }

--- a/src/main/kotlin/moe/sota/decompiler/views/WindowView.kt
+++ b/src/main/kotlin/moe/sota/decompiler/views/WindowView.kt
@@ -93,22 +93,30 @@ private class WindowComponentAdapter(private val windowView: WindowView) : Compo
     }
 }
 
+private val EXTENSIONS = listOf(".jar", ".war", ".zip")
+
 private class WindowDropTarget : DropTarget() {
     override fun dragOver(event: DropTargetDragEvent) {
         event.acceptDrag(DnDConstants.ACTION_MOVE)
     }
 
     override fun drop(event: DropTargetDropEvent) {
+        if (!event.isDataFlavorSupported(DataFlavor.javaFileListFlavor)) {
+            event.rejectDrop()
+            return
+        }
+
         event.acceptDrop(DnDConstants.ACTION_MOVE)
 
-        if (!event.isDataFlavorSupported(DataFlavor.javaFileListFlavor)) return
-
         val files = event.transferable.getTransferData(DataFlavor.javaFileListFlavor) as List<*>
-        val file = files.firstOrNull() as File? ?: return
+        val file = files.firstOrNull() as File?
 
-        if (listOf(".jar", ".war", ".zip").any { file.name.endsWith(it, ignoreCase = true) }) {
-            LoaderService.load(file)
-            event.dropComplete(true)
+        if (file == null || EXTENSIONS.none { file.name.endsWith(it, ignoreCase = true) }) {
+            event.dropComplete(false)
+            return
         }
+
+        LoaderService.load(file)
+        event.dropComplete(true)
     }
 }


### PR DESCRIPTION
The tree was mechanically ported from Java and still read like Java. This pass rewrites all 46 Kotlin sources to idiomatic Kotlin, then fixes the two real defects the review surfaced.

## `refactor: rewrite the ported sources in idiomatic Kotlin`

| Java-ism | Replacement |
|---|---|
| `getRootPane()`, `setSelectedItem()`, `setEnabled()`, … | synthetic properties |
| `String.format(...)` | string templates / `.format()` |
| index loops, `Enumeration` while-loops, accumulator vars | `firstOrNull`, `lastOrNull`, `for (e in jar.entries())`, `forEach` |
| `KoinJavaComponent.get` | `KoinComponent` + `by inject()` |
| `StringWriter` + `PrintWriter` stack traces | `e.stackTraceToString()` |
| `Collections.sort`, `ArrayList()`, `String(bytes, UTF_8)` | `sort()`, `mutableListOf()`, `decodeToString()` |
| `java.util.*` / `javax.swing.*` | explicit imports (~⅓ of the diff) |
| stateless classes, `KeyListener` with empty overrides | `object`, `KeyAdapter` |
| write-only public fields (13 in `AboutView` alone) | locals in `init`; visibility tightened elsewhere |

Behavior-preserving throughout: Swing construction and layout order, listener registration, Koin resolution, coroutine scopes and dispatchers, and every user-visible string are unchanged.

Two spots were rewritten beyond a mechanical swap:

- `TabView.setScrollPane(JScrollPane())` → `showImage()`. It read as a setter for the unrelated `scrollPane` property, and the caller was constructing a scroll pane purely to hand it over.
- `BaseModel.setIcon(path)` → `loadIcon(path)`, for the same reason — it takes a resource path, not an `Image`.

## `fix(views): match dropped archive extensions locale-independently`

The drop target lowercased with `Locale.getDefault()` before comparing against `.jar`/`.war`/`.zip`. Under a Turkish locale `.ZIP` lowercases to `.zıp`, so dropping an upper-case archive silently did nothing.

## `fix(services): bail out when the main class cannot be resolved`

The canonical class name went into `ProcessBuilder` unchecked, so an unresolvable main class threw inside the vararg array instead of skipping the spawn, which is what a missing `java` command already did.

## Left alone

- `SearchService` is dead — unused `database` val plus two empty stubs. Pre-existing; delete it or wire it up separately.
- `WindowView.kt:88` — `windowView.isVisible = windowView.height < maximumWindowBounds.height` hides the whole window when maximised, inside a `macos != null` guard. Looks like it means `windowView.macos?.isVisible`, but confirming that is a behavior change and out of scope here.

## Verification

`./gradlew build -x test` and `spotlessCheck` pass on each of the three commits. The GUI was not launched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved image-file viewing with integrated scrolling and scaling.
  * Enhanced archive and file navigation for smoother tab opening and loading.
* **Bug Fixes**
  * Improved drag-and-drop handling, including case-insensitive archive recognition.
  * Improved error display and text decoding for loaded files.
  * Improved application launching when runtime information is unavailable.
* **Refactor**
  * Streamlined interface behavior and internal component handling without changing expected workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->