### PR TITLE
refactor: scope the async work with structured concurrency

### DIFF
--- a/src/main/kotlin/moe/sota/decompiler/Main.kt
+++ b/src/main/kotlin/moe/sota/decompiler/Main.kt
@@ -3,6 +3,7 @@
 package moe.sota.decompiler
 
 import com.formdev.flatlaf.util.SystemInfo
+import javax.swing.SwingUtilities
 import moe.sota.decompiler.modules.controllersModule
 import moe.sota.decompiler.modules.menusModule
 import moe.sota.decompiler.modules.servicesModule
@@ -18,5 +19,5 @@ fun main(args: Array<String>) {
 
     startKoin { modules(controllersModule, menusModule, servicesModule, viewsModule) }
 
-    Application.run(args)
+    SwingUtilities.invokeLater { Application.run(args) }
 }

--- a/src/main/kotlin/moe/sota/decompiler/controllers/TabController.kt
+++ b/src/main/kotlin/moe/sota/decompiler/controllers/TabController.kt
@@ -2,6 +2,10 @@ package moe.sota.decompiler.controllers
 
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import moe.sota.decompiler.models.FileModel
 import moe.sota.decompiler.transformers.Transformer
@@ -15,30 +19,37 @@ class TabController(
     val tabView: TabView,
     private val tabsController: TabsController,
 ) {
+    private val scope = MainScope()
+
     init {
         tabView.tabController = this
     }
 
-    suspend fun update() {
-        if (fileModel.type is ImageType) {
-            tabView.showImage()
-            return
-        }
+    fun update() {
+        scope.coroutineContext.cancelChildren()
+        scope.launch {
+            if (fileModel.type is ImageType) {
+                tabView.showImage()
+                return@launch
+            }
 
-        try {
-            val transformer = tabsController.transformer
-            tabView.textArea.text = withContext(Dispatchers.Default) { getText(transformer) }
-            fileModel.type?.let { tabView.textArea.syntaxEditingStyle = it.syntax }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Throwable) {
-            tabView.textArea.text = e.stackTraceToString().trim()
-            tabView.textArea.syntaxEditingStyle = SyntaxConstants.SYNTAX_STYLE_NONE
-        }
+            try {
+                val transformer = tabsController.transformer
+                tabView.textArea.text = withContext(Dispatchers.Default) { getText(transformer) }
+                fileModel.type?.let { tabView.textArea.syntaxEditingStyle = it.syntax }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                tabView.textArea.text = e.stackTraceToString().trim()
+                tabView.textArea.syntaxEditingStyle = SyntaxConstants.SYNTAX_STYLE_NONE
+            }
 
-        tabView.scrollPane.horizontalScrollBar.value = 0
-        tabView.scrollPane.verticalScrollBar.value = 0
+            tabView.scrollPane.horizontalScrollBar.value = 0
+            tabView.scrollPane.verticalScrollBar.value = 0
+        }
     }
+
+    fun dispose() = scope.cancel()
 
     private fun getText(transformer: Transformer?): String =
         if (fileModel.type is ClassType) transformer!!.newInstance().transform(fileModel)

--- a/src/main/kotlin/moe/sota/decompiler/controllers/TabsController.kt
+++ b/src/main/kotlin/moe/sota/decompiler/controllers/TabsController.kt
@@ -5,8 +5,6 @@ import java.awt.event.ActionListener
 import java.awt.event.ContainerEvent
 import java.awt.event.ContainerListener
 import javax.swing.ImageIcon
-import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.launch
 import moe.sota.decompiler.menus.file.FileCloseTab
 import moe.sota.decompiler.models.FileModel
 import moe.sota.decompiler.services.PreferenceService
@@ -22,7 +20,6 @@ class TabsController(
     private val createTabController: (FileModel) -> TabController,
 ) : ActionListener, ContainerListener, KoinComponent {
     private val fileCloseTab: FileCloseTab by inject()
-    private val scope = MainScope()
 
     val transformer: Transformer?
         get() = tabsView.comboBox.selectedItem as Transformer?
@@ -43,9 +40,7 @@ class TabsController(
 
     override fun actionPerformed(event: ActionEvent?) {
         PreferenceService.preferences.put("transformer", transformer?.name)
-        controllers
-            .filter { it.fileModel.type is ClassType }
-            .forEach { scope.launch { it.update() } }
+        controllers.filter { it.fileModel.type is ClassType }.forEach { it.update() }
     }
 
     override fun componentAdded(event: ContainerEvent) {
@@ -53,6 +48,7 @@ class TabsController(
     }
 
     override fun componentRemoved(event: ContainerEvent) {
+        (event.child as? TabView)?.tabController?.dispose()
         fileCloseTab.isEnabled = tabsView.tabCount > 0
     }
 
@@ -64,15 +60,9 @@ class TabsController(
         }
 
         val controller = createTabController(fileModel)
-        val icon = ImageIcon(fileModel.icon)
-        val component = controller.tabView
-        scope.launch {
-            controller.update()
-            if (getController(fileModel) == null) {
-                tabsView.addTab(fileModel.name, icon, component)
-                tabsView.selectedComponent = component
-            }
-        }
+        tabsView.addTab(fileModel.name, ImageIcon(fileModel.icon), controller.tabView)
+        tabsView.selectedComponent = controller.tabView
+        controller.update()
     }
 
     fun closeTab() {

--- a/src/main/kotlin/moe/sota/decompiler/controllers/TabsController.kt
+++ b/src/main/kotlin/moe/sota/decompiler/controllers/TabsController.kt
@@ -2,9 +2,9 @@ package moe.sota.decompiler.controllers
 
 import java.awt.event.ActionEvent
 import java.awt.event.ActionListener
+import java.awt.event.ContainerEvent
+import java.awt.event.ContainerListener
 import javax.swing.ImageIcon
-import javax.swing.event.ChangeEvent
-import javax.swing.event.ChangeListener
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import moe.sota.decompiler.menus.file.FileCloseTab
@@ -20,7 +20,7 @@ import org.koin.core.component.inject
 class TabsController(
     private val tabsView: TabsView,
     private val createTabController: (FileModel) -> TabController,
-) : ActionListener, ChangeListener, KoinComponent {
+) : ActionListener, ContainerListener, KoinComponent {
     private val fileCloseTab: FileCloseTab by inject()
     private val scope = MainScope()
 
@@ -35,7 +35,7 @@ class TabsController(
 
     init {
         tabsView.comboBox.addActionListener(this)
-        tabsView.model.addChangeListener(this)
+        tabsView.addContainerListener(this)
         PreferenceService.preferences.get("transformer", null)?.let {
             tabsView.comboBox.selectedItem = Transformer.valueOf(it)
         }
@@ -48,7 +48,11 @@ class TabsController(
             .forEach { scope.launch { it.update() } }
     }
 
-    override fun stateChanged(changeEvent: ChangeEvent?) {
+    override fun componentAdded(event: ContainerEvent) {
+        fileCloseTab.isEnabled = tabsView.tabCount > 0
+    }
+
+    override fun componentRemoved(event: ContainerEvent) {
         fileCloseTab.isEnabled = tabsView.tabCount > 0
     }
 

--- a/src/main/kotlin/moe/sota/decompiler/services/LoaderService.kt
+++ b/src/main/kotlin/moe/sota/decompiler/services/LoaderService.kt
@@ -3,8 +3,12 @@ package moe.sota.decompiler.services
 import java.awt.Taskbar
 import java.io.File
 import java.util.jar.JarFile
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import moe.sota.decompiler.controllers.TabsController
@@ -27,9 +31,10 @@ object LoaderService : KoinComponent {
     private val windowView: WindowView by inject()
 
     fun load(file: File) {
-        scope.launch {
-            setProgressState(Taskbar.State.INDETERMINATE)
+        scope.coroutineContext.cancelChildren()
+        setProgressState(Taskbar.State.INDETERMINATE)
 
+        scope.launch {
             try {
                 val archive =
                     withContext(Dispatchers.IO) {
@@ -37,6 +42,7 @@ object LoaderService : KoinComponent {
 
                         ArchiveModel(file.name).apply {
                             for (entry in jar.entries()) {
+                                ensureActive()
                                 val child =
                                     if (entry.isDirectory) PackageModel(entry.name)
                                     else FileModel(jar, entry)
@@ -48,10 +54,13 @@ object LoaderService : KoinComponent {
                 windowController.activate()
                 tabsController.clearTabs()
                 treeController.setArchive(archive)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 e.printStackTrace(System.err)
             } finally {
-                setProgressState(Taskbar.State.OFF)
+                // A superseded load must leave the progress state to the load that replaced it
+                if (isActive) setProgressState(Taskbar.State.OFF)
             }
         }
     }


### PR DESCRIPTION
Stacked on #38 — review that one first; this PR's diff is against `refactor/idiomatic-kotlin`.

## Premise correction

There was almost no Java async left to replace: one `SwingUtilities.invokeLater`, which is still there because it is the right tool. The actual defect was that the coroutine usage was **unstructured** — two process-lifetime `MainScope()`s, fire-and-forget `launch`, and no cancellation anywhere.

## `fix(app): build the user interface on the event dispatch thread`

`main` called `Application.run` directly on the launcher thread, so the entire Swing hierarchy — including every Koin-constructed view — was created and realized off the EDT. Now wrapped in `SwingUtilities.invokeLater`.

## `fix(controllers): track the tab count from the container`

The close-tab menu item listened to the tabbed pane's **selection model**, which only fires when the selection changes. Two consequences:

- Opening a second tab left the selection on the first, so the item kept whatever enabled state it had.
- `clearTabs()` on a new archive load left it enabled with zero tabs; triggering it called `removeTabAt(-1)` and threw `IndexOutOfBoundsException`.

`ContainerListener` fires on every add and remove, which is what the enabled state actually tracks.

## `refactor(controllers): scope decompilation to the tab it belongs to`

The race: `TabsController.actionPerformed` launched one decompile per open class tab with no cancellation of the previous batch. Switch transformer twice quickly and two decompiles write the same `textArea.text` — **the winner is whichever finishes last, not whichever was requested last**, so the tab can end up showing the previous transformer's output.

Each tab now owns a scope. `update()` cancels its own outstanding work before launching; closing a tab cancels it via `componentRemoved`. `LoaderService` supersedes the previous load the same way, and `ensureActive()` in the archive walk makes that cancellation actually stop work.

Inserting the tab synchronously before decompiling makes the pane authoritative during the event that opened it. That deletes the post-suspension `getController(fileModel) == null` re-check — a hand-rolled guard that did not win its race, since `Dispatchers.Main` queues rather than runs inline, so double-clicking the same node twice built two controllers and threw one away after a full decompile. `TabsController`'s own scope disappears entirely.

**One user-visible change:** a tab now appears immediately and blank, then fills in. That is the mechanism, not a progress feature.

## Known limitation, stated rather than implied

Cancellation here means **abandon, not reclaim**. All four decompilers are synchronous third-party calls with no suspension point, and `withContext` never interrupts the thread, so a superseded decompile runs to completion on its `Dispatchers.Default` worker and only its result is discarded. Rapid transformer switching with many tabs open can therefore queue more work than it retires. Bounding that needs `limitedParallelism`, which is a separate decision. The archive walk is the one place cancellation stops work early.

## Deliberately not done

- No `collectLatest` / `mapLatest` / `cancelAndJoin`. They cancel *and join*, which with uninterruptible decompilers blocks the new request for the full remaining runtime of the abandoned one — strictly worse than a bare `cancel()`.
- No Koin-registered `single<CoroutineScope>` cancelled from `WindowView.dispose()`. `ProcessService.start()` forks a new JVM, so window lifetime equals process lifetime by construction, and `dispose()` calls `exitProcess(0)` — a cancellation there is unobservable by definition, because the EDT never returns to its loop. The cost of this choice: scopes are not cancelled at window close. That is a bet on one-window-per-JVM and must be revisited if a second window ever exists.
- No `Dispatchers.Main.immediate` — it would silently no-op an EDT-side deferral with no compile error.
- Two pre-existing issues left alone as out of scope: `LoaderService` never closes the `JarFile` it opens, and `TabView.showImage` does jar I/O plus image decoding on the EDT.

## Review notes

Two adversarial reviewers ran against the first implementation and both independently flagged the same three things, all now reverted:

- `runCatching` wrapped `ensureActive()`, converting `CancellationException` into `Result.failure`. It only worked because of `withContext`'s prompt-cancellation guarantee. The explicit `catch (CancellationException) { throw e }` is back.
- Replacing `SwingUtilities.invokeLater` with `yield()` made `setArchive` `suspend` for no async work, and introduced a cancellation point that could split the tree-commit in half. kotlinx's own kdoc calls `yield()`-for-ordering an antipattern. Reverted.
- `runBlocking(Dispatchers.Main)` in `main` parked the launcher thread and installed a `BlockingEventLoop` purely to hop to the EDT. Replaced with `SwingUtilities.invokeLater`.

Also restored: the `finally` that resets taskbar progress, guarded with `if (isActive)` so a superseded load leaves the progress state to the load that replaced it.

## Verification

`./gradlew build -x test` and `spotlessCheck` pass on each of the three commits. The GUI was not launched — the races above are timing-dependent and I have not reproduced them interactively.